### PR TITLE
Update 2.md

### DIFF
--- a/exercises/2.md
+++ b/exercises/2.md
@@ -33,9 +33,8 @@ drwxr-xr-x    5 root     root          4096 Mar  2 16:20 lib
 ```
 What happened? Behind the scenes, a lot of stuff happened. When you call `run`,
 1. The Docker client contacts the Docker daemon
-2. The Docker daemon downloads the image (alpine in this case) from Docker Hub
-3. The Docker daemon creates the container and then runs a command in that container.
-4. The Docker daemon streams the output of the command to the Docker client
+2. The Docker daemon creates the container and then runs a command in that container.
+3. The Docker daemon streams the output of the command to the Docker client
 
 When you run `docker run alpine`, you provided a command (`ls -l`), so Docker started the command specified and you saw the listing.
 
@@ -64,7 +63,7 @@ $ docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
-Since no containers are running, you see a blank line. Let's try a more useful variant: `docker ps -a`
+Is _this_ a bug? Also no; when you wrote `exit` in the shell, the process stopped. No containers are running, you see a blank line. Let's try a more useful variant: `docker ps -a`
 
 ```
 $ docker ps -a
@@ -75,16 +74,9 @@ ff0a5c3750b9        alpine              "ls -l"                  8 minutes ago  
 c317d0a9e3d2        hello-world         "/hello"                 34 seconds ago      Exited (0) 12 minutes ago                       stupefied_mcclintock
 ```
 
-What you see above is a list of all containers that you ran. Notice that the `STATUS` column shows that these containers exited a few minutes ago. You're probably wondering if there is a way to run more than just one command in a container. Let's try that now:
+What you see above is a list of all containers that you ran. Notice that the `STATUS` column shows that these containers exited a few minutes ago. 
 
-```
-$ docker run -it alpine /bin/sh
-/ # ls
-bin      dev      etc      home     lib      linuxrc  media    mnt      proc     root     run      sbin     sys      tmp      usr      var
-/ # uname -a
-Linux 97916e8cb5dc 4.4.27-moby #1 SMP Wed Oct 26 14:01:48 UTC 2016 x86_64 Linux
-```
-Running the `run` command with the `-it` flags attaches us to an interactive tty in the container. Now you can run as many commands in the container as you want. Take some time to run your favorite commands.
+Try using the `run` command again with the `-it` flag, so it attaches you to an interactive tty in the container. You can run as many commands in the container as you want! Take some time to run your favorite commands. (Remember, you can write `exit` when you want to quit.)
 
 That concludes a whirlwind tour of the `docker run` command which would most likely be the command you'll use most often. It makes sense to spend some time getting comfortable with it. To find out more about `run`, use `docker run --help` to see a list of all flags it supports. As you proceed further, we'll see a few more variants of `docker run`.
 


### PR DESCRIPTION
Remove part of exercise description; they're not downloading alpine in 1.1 because they did it in the previous step. Docker just runs the image now.
Rephrase part of exercise about printing (stopped) containers.
Remove/Update duplicate part of exercise with interacive shell.