### PR TITLE
change docker container run -> docker run, docker container ls -> doc…

### DIFF
--- a/labs/01-hello-world.md
+++ b/labs/01-hello-world.md
@@ -2,7 +2,7 @@
 
 Try running a command with Docker:
 
-`docker container run hello-world`
+`docker run hello-world`
 
 Your terminal output should look like this:
 
@@ -38,6 +38,6 @@ This message shows that your installation appears to be working correctly.
 
 _*Q: So what did this do?*_
 
-Try to run `docker container run hello-world` again.
+Try to run `docker run hello-world` again.
 
 Docker has now already downloaded the image locally, and can therefore execute the container straight away.

--- a/labs/02-running-images.md
+++ b/labs/02-running-images.md
@@ -5,7 +5,7 @@ Now that you have everything setup, it's time to get your hands dirty. In this s
 To get started, let's run the following in our terminal:
 
 ```bash
-docker image pull alpine
+docker pull alpine
 ```
 
 > **Note:** Depending on how you've installed docker on your system, you might see a `permission denied` error after running the above command. You may need to prefix your `docker` commands with `sudo` as stated before. Alternatively you can [create a docker group](https://docs.docker.com/engine/installation/linux/linux-postinstall/) to get rid of this issue.
@@ -19,12 +19,12 @@ alpine                  latest              c51f86c28340        4 weeks ago     
 hello-world             latest              690ed74de00f        5 months ago        960 B
 ```
 
-## 1.1 docker container run
+## 1.1 docker run
 
 Great! Now let's run a Docker **container** based on this image. To do that you are going to use the `docker container run` command.
 
 ```bash
-$ docker container run alpine ls -l
+$ docker run alpine ls -l
 total 48
 drwxr-xr-x    2 root     root          4096 Mar  2 16:20 bin
 drwxr-xr-x    5 root     root           360 Mar 18 09:47 dev
@@ -41,12 +41,12 @@ What happened? Behind the scenes, a lot of stuff happened. When you call `run`,
 2. The Docker daemon creates the container and then runs a command in that container.
 3. The Docker daemon streams the output of the command to the Docker client
 
-When you run `docker container run alpine`, you provided a command (`ls -l`), so Docker started the command specified and you saw the listing.
+When you run `docker run alpine`, you provided a command (`ls -l`), so Docker started the command specified and you saw the listing.
 
 Let's try something more exciting.
 
 ```bash
-$ docker container run alpine echo "hello from alpine"
+$ docker run alpine echo "hello from alpine"
 hello from alpine
 ```
 
@@ -55,24 +55,24 @@ OK, that's some actual output. In this case, the Docker client dutifully ran the
 Try another command.
 
 ```bash
-docker container run alpine /bin/sh
+docker run alpine /bin/sh
 ```
 
-Wait, nothing happened! Is that a bug? Well, no. These interactive shells will exit after running any scripted commands, unless they are run in an interactive terminal - so for this example to not exit, you need to `docker container run -it alpine /bin/sh`.
+Wait, nothing happened! Is that a bug? Well, no. These interactive shells will exit after running any scripted commands, unless they are run in an interactive terminal - so for this example to not exit, you need to `docker run -it alpine /bin/sh`.
 
 You are now inside the container shell and you can try out a few commands like `ls -l`, `uname -a` and others. Exit out of the container by giving the `exit` command.
 
-Ok, now it's time to see the `docker container ls` command. The `docker container ls` command shows you all containers that are currently running.
+Ok, now it's time to see the `docker ps` command. The `docker ps` command shows you all containers that are currently running.
 
 ```bash
-$ docker container ls
+$ docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
-Is _this_ a bug? Also no; when you wrote `exit` in the shell, the process stopped. No containers are running, you see a blank line. Let's try a more useful variant: `docker container ls -a`
+Is _this_ a bug? Also no; when you wrote `exit` in the shell, the process stopped. No containers are running, you see a blank line. Let's try a more useful variant: `docker ps -a`
 
 ```bash
-$ docker container ls -a
+$ docker ps -a
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                      PORTS               NAMES
 36171a5da744        alpine              "/bin/sh"                5 minutes ago       Exited (0) 2 minutes ago                        fervent_newton
 a6a9d46d0b2f        alpine              "echo 'hello from alp"   6 minutes ago       Exited (0) 6 minutes ago                        lonely_kilby
@@ -88,10 +88,10 @@ Note: the flags `-it` are short for `-i -t` which again are the short forms of `
 
 ## Naming your container
 
-Take a look again at the output of the `docker container ls -a`:
+Take a look again at the output of the `docker ps -a`:
 
 ```bash
-$ docker container ls -a
+$ docker ps -a
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                      PORTS               NAMES
 36171a5da744        alpine              "/bin/sh"                5 minutes ago       Exited (0) 2 minutes ago                        fervent_newton
 a6a9d46d0b2f        alpine              "echo 'hello from alp"   6 minutes ago       Exited (0) 6 minutes ago                        lonely_kilby
@@ -104,4 +104,4 @@ If you want to assign a specific name to a container then you can use the `--nam
 
 ## Summary
 
-That concludes a whirlwind tour of the `docker container run` command which would most likely be the command you'll use most often. It makes sense to spend some time getting comfortable with it. To find out more about `run`, use `docker container run --help` to see a list of all flags it supports. As you proceed further, we'll see a few more variants of `docker container run`.
+That concludes a whirlwind tour of the `docker run` command which would most likely be the command you'll use most often. It makes sense to spend some time getting comfortable with it. To find out more about `run`, use `docker run --help` to see a list of all flags it supports. As you proceed further, we'll see a few more variants of `docker run`.

--- a/labs/03-deletion.md
+++ b/labs/03-deletion.md
@@ -4,7 +4,7 @@ As containers are just a thin base layer on top of the host kernel, it is really
 
 Let's try to run an alpine container and delete the file system.
 
-Spin up the container with `docker container run -ti alpine`
+Spin up the container with `docker run -ti alpine`
 
 list all the folders on the root level to see the whole distribution:
 
@@ -14,7 +14,7 @@ bin    etc    lib    mnt    root   sbin   sys    usr
 dev    home   media  proc   run    srv    tmp    var
 ```
 
-> **Warning:** Do never try to run the following command as a super user in your own environment, as it will delete *everything* on your computer.
+> **Warning:** Do never try to run the following command as a super user in your own environment, as it will delete _everything_ on your computer.
 
 Now, delete the whole file system with `rm -rf /`
 
@@ -32,7 +32,7 @@ Try to navigate around to see how much of the OS is gone
 Exit out by `Ctrl+D` and create a new instance of the Alpine image and look a bit around:
 
 ```
-$ docker container run -ti alpine
+$ docker run -ti alpine
 ls /
 bin    etc    lib    mnt    root   sbin   sys    usr
 dev    home   media  proc   run    srv    tmp    var
@@ -43,7 +43,7 @@ Try to perform the same tasks as displayed above to see that you have a fresh ne
 ## Auto-remove a container after use
 
 Every time you create a new container, it will take up some space, even though it usually is minimal.
-To see what your containers are taking up of space try to run the `docker container ls -as` command.
+To see what your containers are taking up of space try to run the `docker ls -as` command.
 
 ```bash
 CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS                      PORTS                                                          NAMES               SIZE
@@ -53,15 +53,15 @@ CONTAINER ID        IMAGE                     COMMAND                  CREATED  
 Here you can see that the alpine image itself takes 3.97MB, and the container itself takes 0B. When you begin to manipulate files in your container, the size of the container will rise.
 
 If you are creating a lot of new containers eg. to test something, you can tell the Docker daemon to remove the container once stopped with the `--rm` option:
-`docker container run --rm -it alpine`
+`docker run --rm -it alpine`
 
 This will remove the container immediately after it is stopped.
 
 ## Cleaning up containers you do not use anymore
 
 Containers are still persisted, even though they are stopped.
-If you want to delete them from your server you need to use the `docker container rm` command.
-`docker container rm` can take either the `CONTAINER ID` or `NAME` as seen above. Try to remove the `hello-world` container:
+If you want to delete them from your server you need to use the `docker rm` command.
+`docker rm` can take either the `CONTAINER ID` or `NAME` as seen above. Try to remove the `hello-world` container:
 
 ```bash
 sofus@Praq-Sof:~/git/docker-exercises$ docker container ls -a
@@ -110,10 +110,10 @@ Docker provides a `prune` command, taking all dangling containers/images/network
 
 > You need version `1.13` or newer to have access to pruning.
 
-* `docker container prune`
-* `docker image prune`
-* `docker network prune`
-* `docker volume prune`
+- `docker container prune`
+- `docker image prune`
+- `docker network prune`
+- `docker volume prune`
 
 The docker image prune command allows you to clean up unused images. By default, docker image prune only cleans up dangling images. A dangling image is one that is not tagged and is not referenced by any container. To remove all _unused_ resources, resources that are not directly used by any existing containers, use the `-a` switch as well.
 

--- a/labs/04-port-forward.md
+++ b/labs/04-port-forward.md
@@ -2,15 +2,15 @@
 
 Running arbitrary Linux commands inside a Docker container is fun, but let's do something more useful.
 
-Pull down the ``nginx`` Docker image from the Docker Hub. This Docker image uses the [Nginx](http://nginx.org/) webserver to serve a static HTML website.
+Pull down the `nginx` Docker image from the Docker Hub. This Docker image uses the [Nginx](http://nginx.org/) webserver to serve a static HTML website.
 
-Start a new container from the ``nginx`` image that exposes port 80 from the container to port 8080 on your host. You will need to use the ``-p`` flag with the docker container run command.
+Start a new container from the `nginx` image that exposes port 80 from the container to port 8080 on your host. You will need to use the `-p` flag with the docker container run command.
 
 > NB: Mapping ports between your host machine and your containers can get confusing.
 > Here is the syntax you will use:
 >
 > ```bash
-> docker container run -p 8080:80 nginx
+> docker run -p 8080:80 nginx
 > ```
 >
 > The trick is to remember that **the host port always goes to the left**,
@@ -19,18 +19,18 @@ Start a new container from the ``nginx`` image that exposes port 80 from the con
 
 Open a web browser and go to port 8080 on your host. The exact address will depend on how you're running Docker today:
 
-* **Native Linux** - [http://localhost:8080](http://localhost:8080)
-* **Cloud server** - Make sure firewall rules are configured to allow traffic on port 8080. Open browser and use the hostname (or IP) for your server.
-Ex: [http://inst1.training.eficode.academy:8080](http://inst1.training.eficode.academy:8080) -
-Alternatively open a new shell and issue `curl localhost:8080`
-* **Google Cloud Shell** - Open Web Preview (upper right corner)
+- **Native Linux** - [http://localhost:8080](http://localhost:8080)
+- **Cloud server** - Make sure firewall rules are configured to allow traffic on port 8080. Open browser and use the hostname (or IP) for your server.
+  Ex: [http://inst1.training.eficode.academy:8080](http://inst1.training.eficode.academy:8080) -
+  Alternatively open a new shell and issue `curl localhost:8080`
+- **Google Cloud Shell** - Open Web Preview (upper right corner)
 
 If you see a webpage saying "Welcome to nginx!" then you're done!
 
 If you look at the console output from docker, you see nginx producing a line of text for each time a browser hits the webpage:
 
 ```bash
-sofus@Praq-Sof:~/git/docker-exercises$ docker container run -p 8080:80 nginx
+sofus@Praq-Sof:~/git/docker-exercises$ docker run -p 8080:80 nginx
 172.17.0.1 - - [31/May/2017:11:52:48 +0000] "GET / HTTP/1.1" 200 612 "-" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:53.0) Gecko/20100101 Firefox/53.0" "-
 ```
 
@@ -41,10 +41,10 @@ Press **control + c** in your terminal window to stop your container.
 When running a webserver like nginx, it is very useful to not run the container in the foreground of our terminal.
 Instead we should make it run in the background, freeing up our terminal for other things.
 Docker enables this with the `-d` parameter for the `run` command.
-For example: `docker container run -d -p 8080:80 nginx`
+For example: `docker run -d -p 8080:80 nginx`
 
 ```bash
-sofus@Praq-Sof:~/git/docker-exercises$ docker container run -p 8080:80 -d nginx
+sofus@Praq-Sof:~/git/docker-exercises$ docker run -p 8080:80 -d nginx
 78c943461b49584ebdf841f36d113567540ae460387bbd7b2f885343e7ad7554
 ```
 

--- a/labs/05-executing.md
+++ b/labs/05-executing.md
@@ -10,13 +10,13 @@ In this exercise, we want to change a file in an already running container, by e
 
 ### Step by step
 
-- Spin up a new NGINX container: `docker container run -d -p 8000:80 nginx`
+- Spin up a new NGINX container: `docker run -d -p 8000:80 nginx`
 - Visit the webpage to make sure that NGINX have been setup correctly.
 
 Step into a new container by executing a bash shell inside the container:
 
 ```bash
-docker container exec -it CONTAINERNAME bash
+docker exec -it CONTAINERNAME bash
 ```
 
 > :bulb: note that the CONTAINERNAME is the name of the NGINX container you just started.

--- a/labs/06-volumes.md
+++ b/labs/06-volumes.md
@@ -1,6 +1,6 @@
 # Docker volumes
 
-> *Hint: This lab only covers volumes on Docker for Linux. If you are on windows or mac, things can look different.*
+> _Hint: This lab only covers volumes on Docker for Linux. If you are on windows or mac, things can look different._
 
 Not everything can be in a container. The whole idea is that you can start, stop and delete the containers without losing data.
 
@@ -24,8 +24,8 @@ The server itself is of little use, if it cannot access our web content on the h
 
 We need to create a mapping between the host system, and the container with the `-v` command:
 
-``` bash
-docker container run --name some-nginx -v /some/content:/usr/share/nginx/html:ro -d nginx
+```bash
+docker run --name some-nginx -v /some/content:/usr/share/nginx/html:ro -d nginx
 ```
 
 That will map whatever files are in the `/some/content` folder on the host to `/usr/share/nginx/html` in the container.
@@ -34,32 +34,32 @@ That will map whatever files are in the `/some/content` folder on the host to `/
 
 Try to do the following:
 
-* `git clone` this repository down
-    * If you are at training the repository is most likely already cloned on your training VM.
-* Navigate to the `labs/volumes/` directory, which contains a file we can try to serve: `index.html`.
-* We need change `/some/content` to the right path, it must be an absolute path, starting from the root of the filesystem, (which in linux is `/`). You can use the command `pwd` (Print working directory) to display the path to where you are.
-* Now try to run the container with the `labs/volumes` directory bind mounted.
+- `git clone` this repository down
+  - If you are at training the repository is most likely already cloned on your training VM.
+- Navigate to the `labs/volumes/` directory, which contains a file we can try to serve: `index.html`.
+- We need change `/some/content` to the right path, it must be an absolute path, starting from the root of the filesystem, (which in linux is `/`). You can use the command `pwd` (Print working directory) to display the path to where you are.
+- Now try to run the container with the `labs/volumes` directory bind mounted.
 
 This will give you a nginx server running, serving your static files... _But on which port?_
 
-* Run a `docker container ls` command to find out if it has any ports forwarded from the host.
+- Run a `docker ps` command to find out if it has any ports forwarded from the host.
 
 Remember the [past exercise](04-port-forward.md) on port forwarding in Docker.
 
-* Make it host the site on port 8000
-* Check that it is running by navigating to the hostname or IP with your browser, and on port 8000.
+- Make it host the site on port 8000
+- Check that it is running by navigating to the hostname or IP with your browser, and on port 8000.
 
 ## Volumes
 
 Volumes are entities inside docker, and can be created in three different ways.
 
-* By explicitly creating it with the `docker volume create <volume_name>` command
-* By creating a named volume at container creation time with `docker container run -d -v DataVolume:/opt/app/data nginx`
-* By creating an anonymous volume at container creation time with `docker container run -d -v /opt/app/data nginx`
+- By explicitly creating it with the `docker volume create <volume_name>` command
+- By creating a named volume at container creation time with `docker container run -d -v DataVolume:/opt/app/data nginx`
+- By creating an anonymous volume at container creation time with `docker container run -d -v /opt/app/data nginx`
 
 First off, lets try to make a data volume called `data`:
 
-``` bash
+```bash
 docker volume create data
 ```
 
@@ -114,7 +114,7 @@ Multiple containers can attach to the same volume with data. Docker doesn't hand
 Let's try to go in and make a new html page for nginx to serve. We do this by making a new ubuntu container that has the `data` volume attached to `/tmp`, and thereafter create a new html file with the `echo` command:
 
 ```bash
-docker container run -ti --rm -v data:/tmp ubuntu bash
+docker run -ti --rm -v data:/tmp ubuntu bash
 root@9c36fcfcc048:# echo "<html><h1>hello world</h1></html>" > /tmp/hello.html
 root@9c36fcfcc048:# ls /tmp
 hello.html  50x.html  index.html
@@ -124,12 +124,12 @@ Head over to your newly created webpage at: `http://<IP>:8080/hello.html`
 
 ## cleanup
 
-Exit out of your ubuntu server and execute a `docker container stop www` to stop the nginx container.
+Exit out of your ubuntu server and execute a `docker stop www` to stop the nginx container.
 
-Run a `docker container ls` to make sure that no other containers are running.
+Run a `docker ps` to make sure that no other containers are running.
 
 ```bash
-docker container ls
+docker ps
 CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS              PORTS                                                          NAMES
 ```
 
@@ -139,8 +139,8 @@ The data volume is still present, and will be there until you remove it with a `
 
 As you have seen, the `-v` flag can both create a bind mount or name a volume depending on the syntax. If the first argument begins with a / or ~/ you're creating a bind mount. Remove that, and you're naming the volume. For example:
 
-* `-v /path:/path/in/container` mounts the host directory, `/path` at the `/path/in/container`
-* `-v path:/path/in/container` creates a volume named path with no relationship to the host.
+- `-v /path:/path/in/container` mounts the host directory, `/path` at the `/path/in/container`
+- `-v path:/path/in/container` creates a volume named path with no relationship to the host.
 
 ### Sharing data
 
@@ -150,13 +150,13 @@ If you want to share volumes or bind mount between two containers, then use the 
 
 Before you go on, use the [Docker command line interface](https://docs.docker.com/engine/reference/commandline/cli/) documentation to try a few more commands:
 
-* While your detached container is running, use the ``docker container ls`` command to see what silly name Docker gave your container. **This is one command you're going to use often!**
-* While your detached container is still running, look at its logs. Try following its logs and refreshing your browser.
-* Stop your detached container, and confirm that it is stopped with the `ls` command.
-* Start it again, wait 10 seconds for it to fire up, and stop it again.
-* Then delete that container from your system.
+- While your detached container is running, use the `docker ps` command to see what silly name Docker gave your container. **This is one command you're going to use often!**
+- While your detached container is still running, look at its logs. Try following its logs and refreshing your browser.
+- Stop your detached container, and confirm that it is stopped with the `ls` command.
+- Start it again, wait 10 seconds for it to fire up, and stop it again.
+- Then delete that container from your system.
 
-> **NOTE:** When running most docker commands, you only need to specify the first few characters of a container's ID. For example, if a container has the ID ``df4fd19392ba``, you can stop it with ``docker container stop df4``. You can also use the silly names Docker provides containers by default, such as ``boring_bardeen``.
+> **NOTE:** When running most docker commands, you only need to specify the first few characters of a container's ID. For example, if a container has the ID `df4fd19392ba`, you can stop it with `docker stop df4`. You can also use the silly names Docker provides containers by default, such as `boring_bardeen`.
 
 If you want to read more, I recommend [Digital Oceans](https://www.digitalocean.com/community/tutorials/how-to-share-data-between-docker-containers) guides to sharing data through containers, as well as Dockers own article about [volumes](https://docs.docker.com/engine/admin/volumes).
 

--- a/labs/07-building-an-image.md
+++ b/labs/07-building-an-image.md
@@ -33,10 +33,10 @@ Details:
   CMD ["/bin/bash", "echo", "Hello World"]
 ```
 
-- `EXPOSE` creates a hint for users of an image that provides services on ports. It is included in the information which can be retrieved via `$ docker container inspect <container-id>`.
+- `EXPOSE` creates a hint for users of an image that provides services on ports. It is included in the information which can be retrieved via `$ docker inspect <container-id>`.
 
 > **Note:** The `EXPOSE` command does not actually make any ports accessible to the host! Instead, this requires
-publishing ports by means of the `-p` or `-P` flag when using `$ docker container run`.
+> publishing ports by means of the `-p` or `-P` flag when using `$ docker run`.
 
 - `ENTRYPOINT` configures a command that will run no matter what the user specifies at runtime.
 
@@ -50,86 +50,86 @@ As mentioned above, all user images are based on a _base image_. Since our appli
 
 A [Dockerfile](https://docs.docker.com/engine/reference/builder/) is a text file containing a list of commands that the Docker daemon calls while creating an image. The Dockerfile contains all the information that Docker needs to know to run the app; a base Docker image to run from, location of your project code, any dependencies it has, and what commands to run at start-up.
 
-It is a simple way to automate the image creation process. The best part is that the [commands](https://docs.docker.com/engine/reference/builder/) you write in a Dockerfile are *almost* identical to their equivalent Linux commands. This means you don't really have to learn new syntax to create your own Dockerfiles.
+It is a simple way to automate the image creation process. The best part is that the [commands](https://docs.docker.com/engine/reference/builder/) you write in a Dockerfile are _almost_ identical to their equivalent Linux commands. This means you don't really have to learn new syntax to create your own Dockerfiles.
 
 1. Create a file called **Dockerfile**, and add content to it as described below. We have made a small boilerplate file and app for you in the [/building-an-image](./building-an-image/) folder, so head over there.
 
-    > If you want to make a file from scratch, you can use the linux command `touch <filename>` to create an empty file, and the text editor `nano <filename>` to manipulate the file.
+   > If you want to make a file from scratch, you can use the linux command `touch <filename>` to create an empty file, and the text editor `nano <filename>` to manipulate the file.
 
-    We'll start by specifying our base image, using the `FROM` keyword:
+   We'll start by specifying our base image, using the `FROM` keyword:
 
-    ```docker
-    FROM ubuntu:latest
-    ```
+   ```docker
+   FROM ubuntu:latest
+   ```
 
 1. The next step is usually to write the commands of copying the files and installing the dependencies. But first we will install the Python pip package to the ubuntu linux distribution. This will not just install the pip package but any other dependencies too, which includes the python interpreter. Add the following [RUN](https://docs.docker.com/engine/reference/builder/#run) command next:
 
-    ```docker
-    RUN apt-get update -y
-    RUN apt-get install -y python3 python3-pip python3-dev build-essential
-    ```
+   ```docker
+   RUN apt-get update -y
+   RUN apt-get install -y python3 python3-pip python3-dev build-essential
+   ```
 
 1. Let's add the files that make up the Flask Application.
 
-    Install all Python requirements for our app to run. This will be accomplished by adding the lines:
+   Install all Python requirements for our app to run. This will be accomplished by adding the lines:
 
-    ```docker
-    COPY requirements.txt /usr/src/app/
-    RUN pip3 install --no-cache-dir -r /usr/src/app/requirements.txt
-    ```
+   ```docker
+   COPY requirements.txt /usr/src/app/
+   RUN pip3 install --no-cache-dir -r /usr/src/app/requirements.txt
+   ```
 
-    Copy the application app.py into our image by using the [COPY](https://docs.docker.com/engine/reference/builder/#copy)  command.
+   Copy the application app.py into our image by using the [COPY](https://docs.docker.com/engine/reference/builder/#copy) command.
 
-    ```docker
-    COPY app.py /usr/src/app/
+   ```docker
+   COPY app.py /usr/src/app/
 
-    ```
+   ```
 
 1. Specify the port number which needs to be exposed. Since our flask app is running on `5000` that's what we'll expose.
 
-    ```docker
-    EXPOSE 5000
-    ```
+   ```docker
+   EXPOSE 5000
+   ```
 
-    > The `EXPOSE` instruction does not actually publish the port.
-    > It functions as a type of documentation between the person who builds the
-    > image and the person who runs the container,
-    > about which ports are intended to be published.
-    > You need the `-p`/`-P` command to actually open the host ports.
+   > The `EXPOSE` instruction does not actually publish the port.
+   > It functions as a type of documentation between the person who builds the
+   > image and the person who runs the container,
+   > about which ports are intended to be published.
+   > You need the `-p`/`-P` command to actually open the host ports.
 
 1. The last step is the command for running the application which is simply - `python3 ./app.py`. Use the [CMD](https://docs.docker.com/engine/reference/builder/#cmd) command to do that:
 
-    ```docker
-    CMD ["python3", "/usr/src/app/app.py"]
-    ```
+   ```docker
+   CMD ["python3", "/usr/src/app/app.py"]
+   ```
 
-    The primary purpose of `CMD` is to tell the container which command it should run by default when it is started.
+   The primary purpose of `CMD` is to tell the container which command it should run by default when it is started.
 
 1. Verify your Dockerfile.
 
-    Our `Dockerfile` is now ready. This is how it looks:
+   Our `Dockerfile` is now ready. This is how it looks:
 
-    ```docker
-    # The base image
-    FROM ubuntu:latest
+   ```docker
+   # The base image
+   FROM ubuntu:latest
 
-    # Install python and pip
-    RUN apt-get update -y
-    RUN apt-get install -y python3 python3-pip python3-dev build-essential
+   # Install python and pip
+   RUN apt-get update -y
+   RUN apt-get install -y python3 python3-pip python3-dev build-essential
 
-    # Install Python modules needed by the Python app
-    COPY requirements.txt /usr/src/app/
-    RUN pip3 install --no-cache-dir -r /usr/src/app/requirements.txt
+   # Install Python modules needed by the Python app
+   COPY requirements.txt /usr/src/app/
+   RUN pip3 install --no-cache-dir -r /usr/src/app/requirements.txt
 
-    # Copy files required for the app to run
-    COPY app.py /usr/src/app/
+   # Copy files required for the app to run
+   COPY app.py /usr/src/app/
 
-    # Declare the port number the container should expose
-    EXPOSE 5000
+   # Declare the port number the container should expose
+   EXPOSE 5000
 
-    # Run the application
-    CMD ["python3", "/usr/src/app/app.py"]
-    ```
+   # Run the application
+   CMD ["python3", "/usr/src/app/app.py"]
+   ```
 
 ### Build the image
 
@@ -261,7 +261,7 @@ The next step in this section is to run the image and see if it actually works.
 
 ```bash
 
-$ docker container run -p 8888:5000 --name myfirstapp myfirstapp
+$ docker run -p 8888:5000 --name myfirstapp myfirstapp
  * Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
 ```
 
@@ -330,7 +330,7 @@ Removing intermediate container 61a68a949d68
 Step 7/8 : EXPOSE 5000
  ---> Running in 1f939928b7d5
  ---> 6c14a93b72f2
- ```
+```
 
 So what docker actually does is
 
@@ -343,7 +343,7 @@ in a loop untill all the commands have been made.
 Try to create a container from your `COPY app.py /usr/src/app/` command.
 The id of the layer will likely be different than the example above.
 
-`docker container run -ti -p 5000:5000 6ed47d3c544a bash`.
+`docker run -ti -p 5000:5000 6ed47d3c544a bash`.
 
 You are now in a container run from _that_ layer in the build script. You can't make the `EXPOSE` command, but you can look around, and run the last python app:
 
@@ -364,10 +364,10 @@ And just like the image you built above, you can browse the website now.
 
 ### Delete your image
 
-If you make a `docker container ls -a` command, you can now see a container with the name *myfirstapp* from the image named *myfirstapp*.
+If you make a `docker ps -a` command, you can now see a container with the name _myfirstapp_ from the image named _myfirstapp_.
 
 ```bash
-sofus@Praq-Sof:/4$ docker container ls -a
+sofus@Praq-Sof:/4$ docker ps -a
 CONTAINER ID        IMAGE                     COMMAND                  CREATED              STATUS                      PORTS                                                          NAMES
 fcfba2dfb8ee        myfirstapp                "python3 /usr/src/a..."   About a minute ago   Exited (0) 28 seconds ago                                                                  myfirstapp
 ```
@@ -388,11 +388,11 @@ Here is the list of all the instructions that can be used in a Dockerfile:
 - [FROM](https://docs.docker.com/engine/reference/builder/#from) Sets the Base Image for subsequent instructions.
 - [RUN](https://docs.docker.com/engine/reference/builder/#run) execute any commands in a new layer on top of the current image and commit the results.
 - [CMD](https://docs.docker.com/engine/reference/builder/#cmd) provide defaults for an executing container.
-- [EXPOSE](https://docs.docker.com/engine/reference/builder/#expose) informs Docker that the container listens on the specified network ports at runtime.  NOTE: does not actually make ports accessible.
+- [EXPOSE](https://docs.docker.com/engine/reference/builder/#expose) informs Docker that the container listens on the specified network ports at runtime. NOTE: does not actually make ports accessible.
 - [ENV](https://docs.docker.com/engine/reference/builder/#env) sets environment variable.
-- [ADD](https://docs.docker.com/engine/reference/builder/#add) copies new files, directories or remote file to container.  Invalidates caches. Avoid `ADD` and use `COPY` instead.
-- [COPY](https://docs.docker.com/engine/reference/builder/#copy) copies new files or directories to container.  Note that this only copies as root, so you have to chown manually regardless of your USER / WORKDIR setting.
-See [https://github.com/moby/moby/issues/301109](https://github.com/moby/moby/issues/30110)
+- [ADD](https://docs.docker.com/engine/reference/builder/#add) copies new files, directories or remote file to container. Invalidates caches. Avoid `ADD` and use `COPY` instead.
+- [COPY](https://docs.docker.com/engine/reference/builder/#copy) copies new files or directories to container. Note that this only copies as root, so you have to chown manually regardless of your USER / WORKDIR setting.
+  See [https://github.com/moby/moby/issues/301109](https://github.com/moby/moby/issues/30110)
 - [ENTRYPOINT](https://docs.docker.com/engine/reference/builder/#entrypoint) configures a container that will run as an executable.
 - [VOLUME](https://docs.docker.com/engine/reference/builder/#volume) creates a mount point for externally mounted volumes or other containers.
 - [USER](https://docs.docker.com/engine/reference/builder/#user) sets the user name for following RUN / CMD / ENTRYPOINT commands.

--- a/labs/09-multi-container.md
+++ b/labs/09-multi-container.md
@@ -18,13 +18,12 @@ Both containers already exists on the dockerhub: [Wordpress](https://hub.docker.
 To start a mysql container, issue the following command
 
 ```bash
-docker container run --name mysql-container --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=wordpress -e MYSQL_DATABASE=wordpressdb -d mysql:5.7
+docker run --name mysql-container --rm -p 3306:3306 -e MYSQL_ROOT_PASSWORD=wordpress -e MYSQL_DATABASE=wordpressdb -d mysql:5.7
 ```
 
 Let's recap what this command does:
 
 - `docker` invokes the docker engine
-- `container` manage the container part of docker
 - `run` tells docker to run a new container off an image
 - `--name mysql-container` gives the new container a name for better referencing
 - `--rm` tells docker to remove the container after it is stopped
@@ -42,7 +41,7 @@ You can either use the external IP address of your server, or the docker host IP
 After you have noted down the IP, spin up the wordpress container with the host IP as a variable:
 
 ```bash
-docker container run --name wordpress-container --rm -e WORDPRESS_DB_HOST=172.17.0.1 -e WORDPRESS_DB_PASSWORD=wordpress -e WORDPRESS_DB_USER=root -e WORDPRESS_DB_NAME=wordpressdb -p 8080:80 -d wordpress
+docker run --name wordpress-container --rm -e WORDPRESS_DB_HOST=172.17.0.1 -e WORDPRESS_DB_PASSWORD=wordpress -e WORDPRESS_DB_USER=root -e WORDPRESS_DB_NAME=wordpressdb -p 8080:80 -d wordpress
 ```
 
 You can now browse to the IP:8080 and have your very own wordpress server running. Since port 3306 is the default MySQL port, wordpress will try to connect on that port by itself.
@@ -69,10 +68,10 @@ Docker will return the `networkID` for the newly created network. You can refere
 Now you need to connect the two containers to the network, by adding the `--network` option:
 
 ```bash
-docker container run --name mysql-container --rm --network if_wordpress -e MYSQL_ROOT_PASSWORD=wordpress -e MYSQL_DATABASE=wordpressdb -d mysql:5.7
+docker run --name mysql-container --rm --network if_wordpress -e MYSQL_ROOT_PASSWORD=wordpress -e MYSQL_DATABASE=wordpressdb -d mysql:5.7
 af38acac52301a7c9689d708e6c3255704cdffb1972bcc245d67b02840983a50
 
-docker container run --name wordpress-container --rm --network if_wordpress -e WORDPRESS_DB_HOST=mysql-container -e WORDPRESS_DB_PASSWORD=wordpress -e WORDPRESS_DB_USER=root -e WORDPRESS_DB_NAME=wordpressdb -p 8080:80 -d wordpress
+docker run --name wordpress-container --rm --network if_wordpress -e WORDPRESS_DB_HOST=mysql-container -e WORDPRESS_DB_PASSWORD=wordpress -e WORDPRESS_DB_USER=root -e WORDPRESS_DB_NAME=wordpressdb -p 8080:80 -d wordpress
 fd4fd096c064094d7758cefce41d0f1124e78b86623160466973007cf0af8556
 ```
 
@@ -131,16 +130,16 @@ As, we have linked both the container now wordpress container can be accessed fr
 
 Close both of the containers down by issuing the following command:
 
-`docker container stop wordpress-container mysql-container`
+`docker stop wordpress-container mysql-container`
 
 ## Using Docker compose
 
 If you have started working with Docker and are building container images for your application services, you most likely have noticed that after a while you may end up writing long `docker container run` commands.
 These commands, while very intuitive, can become cumbersome to write, especially if you are developing a multi-container applications and spinning up containers quickly.
 
-[Docker Compose](https://docs.docker.com/compose/install/) is a “*tool for defining and running your multi-container Docker applications*”.
+[Docker Compose](https://docs.docker.com/compose/install/) is a “_tool for defining and running your multi-container Docker applications_”.
 
-Your applications can be defined in a YAML file where all the options that you used in `docker container run` are defined.
+Your applications can be defined in a YAML file where all the options that you used in `docker run` are defined.
 
 Compose also allows you to manage your application as a single entity rather than dealing with individual containers.
 
@@ -155,7 +154,7 @@ This file defines all of the containers and settings you need to launch your set
   - `down` : stops and removes containers, networks, images, and volumes
   - `restart` :
   - `logs` : streams the acummulated logs from all the containers in the compose file
-  - `ps` : same as pure `docker container` variant; shows you all containers that are currently running.
+  - `ps` : same as `docker ps`; shows you all containers that are currently running.
   - `rm` : removes all the containers from the given compose file.
   - `start` : starts the services
   - `stop` : stops the services
@@ -185,11 +184,10 @@ Open the file `docker.compose.yaml` with a text editor:
 You should see something like this:
 
 ```yaml
-version: '3.1'
+version: "3.1"
 
 services:
-
-#  wordpress_container:
+  #  wordpress_container:
 
   mysql_container:
     image: mysql:5.7


### PR DESCRIPTION
Change docker command syntax
* docker container run --> docker run
* docker container ls --> docker ps

Motivation is that we never use the long syntax, and it tends to cause confusion.