### PR TITLE
Docker Compose v2 Cleanup

### DIFF
--- a/labs/09-multi-container.md
+++ b/labs/09-multi-container.md
@@ -195,8 +195,6 @@ Open the file `docker.compose.yaml` with a text editor:
 You should see something like this:
 
 ```yaml
-version: "3.1"
-
 services:
   #  wordpress_container:
 

--- a/labs/09-multi-container.md
+++ b/labs/09-multi-container.md
@@ -173,16 +173,16 @@ This file defines all of the containers and settings you need to launch your set
 The docker cli is used when managing individual containers on a docker engine.
 It is the client command line to access the docker daemon api.
 
-The docker-compose cli together with the yaml files can be used to manage a multi-container application.
+The docker compose cli together with the yaml files can be used to manage a multi-container application.
 
 ## Compose-erizing your wordpress
 
-So we want to take advantage of docker-compose to run our wordpress site.
+So we want to take advantage of docker compose to run our wordpress site.
 
 In order to to this we need to:
 
 1. Transform our setup into a docker-compose.yaml file
-1. Invoke docker-compose and watch the magic happen!
+1. Invoke docker compose and watch the magic happen!
 
 Head over to this labs folder:
 
@@ -215,7 +215,7 @@ This is the template we are building our compose file upon so let's drill this o
   - `wordpress_container` is the section where we define our wordpress container
   - `mysql_container` is the ditto of MySQL.
 
-> For more information on docker-compose yaml files, head over to the [documentation](https://docs.docker.com/compose/overview/).
+> For more information on docker compose yaml files, head over to the [documentation](https://docs.docker.com/compose/overview/).
 
 The `services` part is equivalent to our `docker container run` command. Likewise there is a `network` and `volumes` section for those as well corresponding to `docker network create` and `docker volume create`.
 
@@ -225,7 +225,7 @@ Let's look the mysql_container part together, making you able to create the othe
 
 The command gives out following information: a `name`, a `port` mapping, two `environment` variables and the `image` we want to run.
 
-Now look at the docker-compose example again:
+Now look at the docker compose example again:
 
 - `mysql_container` defines the name of the container
 - `image:wordpress` describes what image the container spins up from.

--- a/labs/advanced/containers-on-docker-compose-network.md
+++ b/labs/advanced/containers-on-docker-compose-network.md
@@ -1,11 +1,11 @@
-# Exploration - Containers on docker-compose bridge network
-In this exercise, you will explore various characterstics of the docker-compose network bridge, and the containers running in that network. 
+# Exploration - Containers on docker compose bridge network
+In this exercise, you will explore various characterstics of the docker compose network bridge, and the containers running in that network.
 
-Spoiler: Network created by `docker-compose` are same as user-defined networks. These networks and the containers running in these networks exihibit similar behavior.
+Spoiler: Network created by `docker compose` are same as user-defined networks. These networks and the containers running in these networks exihibit similar behavior.
 
 ## Create/run a multi-container `docker-compose.yml` application:
 ```
-$ vi docker-compose.yml 
+$ vi docker-compose.yml
 version: "3"
 services:
   apache:
@@ -15,9 +15,9 @@ services:
     environment:
       - POSTGRES_PASSWORD=secret
 
-$ docker-compose up -d
+$ docker compose up -d
 
-$ docker-compose ps
+$ docker compose ps
 ```
 
 Note: `praqma/network-multitool` is a small image with lots of network troubleshooting tools installed in it. It also runs a nginx web server on port 80 by default. Most of our examples will use this image in the *web* role. Just think of it as nginx image, with some extra bells and whistles. You can  replace Apache `httpd:alpine` image with `praqma/network-multitool` image in the above example, if you want to.
@@ -27,11 +27,11 @@ Note: `praqma/network-multitool` is a small image with lots of network troublesh
 * See what network interfaces exist on the host network? Do you see docker0?
 * Do you see any other/additional network interface? (e.g br-123zbc456xyz)
 * Inpsect docker0 bridge.
-* Inpsect the newly created docker-compose bridge (e.g br-123zbc456xyz).
-* What does the docker-compose network (bridge) interface on the host look like? (IP/network address, NetMask, MAC address, etc?)
+* Inpsect the newly created docker compose bridge (e.g br-123zbc456xyz).
+* What does the docker compose network (bridge) interface on the host look like? (IP/network address, NetMask, MAC address, etc?)
 * What are the IP addresses of the containers?
-* What DNS resolver do these containers use? 
-* Can the containers on the docker-compose bridge network access each other by their names? IP addresses?
+* What DNS resolver do these containers use?
+* Can the containers on the docker compose bridge network access each other by their names? IP addresses?
 * Do you see any **veth** interfaces on the host?
 * Compare MAC addresses of veth interfaces on the host and the **eth0** interfaces on each container.
 * Inspect containers for their IP addresses, MAC addresses, etc.
@@ -49,6 +49,6 @@ Note: `praqma/network-multitool` is a small image with lots of network troublesh
 * docker exec -it <container name|id> </some/shell>
 * ip addr show
 * netstat
-* iptables -L 
+* iptables -L
 * iptables -t nat -L
 * iptables-save (This will not *save* any rules. It will just list them on the screen.)

--- a/labs/advanced/containers-on-docker-compose-network.md
+++ b/labs/advanced/containers-on-docker-compose-network.md
@@ -6,7 +6,6 @@ Spoiler: Network created by `docker compose` are same as user-defined networks. 
 ## Create/run a multi-container `docker-compose.yml` application:
 ```
 $ vi docker-compose.yml
-version: "3"
 services:
   apache:
     image: httpd:alpine

--- a/labs/advanced/systemd/README.md
+++ b/labs/advanced/systemd/README.md
@@ -13,13 +13,13 @@ docker run -p 80:80 -p 25:25 \
   -d local/centos7:mailserver
 ```
 
-# Build and run using docker-compose:
+# Build and run using docker compose:
 There is a docker-compose.yml, which can be used to build and run this container image. Of-course a Dockerfile is a pre-requisite.
 
 ```
-docker-compose build
+docker compose build
 
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Verify:

--- a/labs/advanced/systemd/docker-compose.yml
+++ b/labs/advanced/systemd/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   mailserver:
     build: .

--- a/labs/advanced/traefik/example1/docker-compose.yml
+++ b/labs/advanced/traefik/example1/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   traefik:
     image: traefik:1.7

--- a/labs/advanced/traefik/example2/README.md
+++ b/labs/advanced/traefik/example2/README.md
@@ -7,10 +7,10 @@ docker network create services-network
 ```
 
 ## Start Traefik - frond-end / proxy:
-Start the Traefik proxy service by briging up it's docker-compose stack - which is compose of just one container!
+Start the Traefik proxy service by briging up it's docker compose stack - which is compose of just one container!
 ```
 cd proxy
-docker-compose up -d
+docker compose up -d
 cd ..
 ```
 Note: Please go through the actual `docker-compose.yml` and `traefik.toml` files under the `proxy` directory.
@@ -26,7 +26,7 @@ CONTAINER ID        IMAGE                      COMMAND                  CREATED 
 ## Start the  web server - back-end:
 ```
 cd web
-docker-compose up -d
+docker compose up -d
 cd ..
 ```
 Note: Please go through the actual `docker-compose.yml` file under the `web` directory.

--- a/labs/advanced/traefik/example2/README.md
+++ b/labs/advanced/traefik/example2/README.md
@@ -1,5 +1,5 @@
-# Traefik proxy running as independent docker-compose app:
-In this example, Traefik runs as an independent docker-compose application. For other applications requiring it's "proxy" services, they need to be on the same network as of the Traefik proxy. The best way is to make a docker bridge network ourselves, and connect all containers on that network. 
+# Traefik proxy running as independent docker compose app:
+In this example, Traefik runs as an independent docker compose application. For other applications requiring it's "proxy" services, they need to be on the same network as of the Traefik proxy. The best way is to make a docker bridge network ourselves, and connect all containers on that network.
 
 ## Create a docker bridge network - **services-network**:
 ```
@@ -46,7 +46,7 @@ For this example, you can setup the following in your `/etc/hosts` file:
 $ cat /etc/hosts
 
 127.0.0.1	localhost	localhost.localdomain
-. . . 
+. . .
 127.0.0.1	example.com	www.example.com
 ```
 
@@ -59,7 +59,7 @@ $ curl www.example.com
 Praqma Network MultiTool (with NGINX) - 65b42f52017a - 172.20.0.3/16
 ```
 
-Notice that `curl localhost` will not work, because the proxy is listening on localhost, on port 80, expecting only the DNS names/URLs, which are configured as it's front-ends. It will ignore all other urls , and will show a `404` . 
+Notice that `curl localhost` will not work, because the proxy is listening on localhost, on port 80, expecting only the DNS names/URLs, which are configured as it's front-ends. It will ignore all other urls , and will show a `404` .
 
 ```
 $ curl localhost

--- a/labs/advanced/traefik/example2/proxy/docker-compose.yml
+++ b/labs/advanced/traefik/example2/proxy/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   traefik:
     image: traefik:1.7

--- a/labs/advanced/traefik/example2/web/docker-compose.yml
+++ b/labs/advanced/traefik/example2/web/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   multitool:
     image: praqma/network-multitool

--- a/labs/advanced/traefik/example3/docker-compose.yml
+++ b/labs/advanced/traefik/example3/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   traefik:
     image: traefik:1.7

--- a/labs/docker-compose/00-getting-started.md
+++ b/labs/docker-compose/00-getting-started.md
@@ -4,4 +4,4 @@ In this section you will install Docker and run your container using compose.
 
 ## Installing Docker
 
-Depending on what OS you are running, installation is different, but head over to the [docker-compose installation instructions](https://docs.docker.com/compose/install/) website and follow the instructions there.
+Depending on what OS you are running, installation is different, but head over to the [docker compose installation instructions](https://docs.docker.com/compose/install/) website and follow the instructions there.

--- a/labs/docker-compose/01-hello-world.md
+++ b/labs/docker-compose/01-hello-world.md
@@ -7,18 +7,14 @@ Try running a command with docker compose:
 Your terminal output should look like this:
 
 ```bash
-ERROR:
-        Can't find a suitable configuration file in this directory or any
-        parent. Are you in the right directory?
-
-        Supported filenames: docker-compose.yml, docker-compose.yaml
+no configuration file provided: not found
 ```
+
 Now we need to create docker-compose.yml as the message suggests.
 
 Open editor and create new file with following content:
 
 ```yml
-version: '3'
 services:
     hello-world:
         image: hello-world:latest
@@ -58,7 +54,6 @@ As we can see. The hello-world container (tagged with latest) was started using 
 
 Compose file explained:
 
-`version: '3'`: defines the API version that docker compose should use
 `services:`:  defines the configuration of the container
 `hello-world:`: is now the name of the service
 `image: hello-world:latest`: defines the container and its version that we're using for `hello-world` service.

--- a/labs/docker-compose/01-hello-world.md
+++ b/labs/docker-compose/01-hello-world.md
@@ -1,13 +1,13 @@
 # hello-world
 
-Try running a command with docker-compose:
+Try running a command with docker compose:
 
-`docker-compose up`
+`docker compose up`
 
 Your terminal output should look like this:
 
 ```bash
-ERROR: 
+ERROR:
         Can't find a suitable configuration file in this directory or any
         parent. Are you in the right directory?
 
@@ -24,15 +24,15 @@ services:
         image: hello-world:latest
 ```
 
-Now try to run again `docker-compose up` and you should see following message:
+Now try to run again `docker compose up` and you should see following message:
 
 ```bash
 Starting docker-compose_hello-world_1 ... done
 Attaching to docker-compose_hello-world_1
-hello-world_1  | 
+hello-world_1  |
 hello-world_1  | Hello from Docker!
 hello-world_1  | This message shows that your installation appears to be working correctly.
-hello-world_1  | 
+hello-world_1  |
 hello-world_1  | To generate this message, Docker took the following steps:
 hello-world_1  |  1. The Docker client contacted the Docker daemon.
 hello-world_1  |  2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
@@ -41,24 +41,24 @@ hello-world_1  |  3. The Docker daemon created a new container from that image w
 hello-world_1  |     executable that produces the output you are currently reading.
 hello-world_1  |  4. The Docker daemon streamed that output to the Docker client, which sent it
 hello-world_1  |     to your terminal.
-hello-world_1  | 
+hello-world_1  |
 hello-world_1  | To try something more ambitious, you can run an Ubuntu container with:
 hello-world_1  |  $ docker run -it ubuntu bash
-hello-world_1  | 
+hello-world_1  |
 hello-world_1  | Share images, automate workflows, and more with a free Docker ID:
 hello-world_1  |  https://hub.docker.com/
-hello-world_1  | 
+hello-world_1  |
 hello-world_1  | For more examples and ideas, visit:
 hello-world_1  |  https://docs.docker.com/get-started/
-hello-world_1  | 
+hello-world_1  |
 docker-compose_hello-world_1 exited with code 0
 ```
 
-As we can see. The hello-world container (tagged with latest) was started using the the compose file and your docker-compose installation is working!
+As we can see. The hello-world container (tagged with latest) was started using the the compose file and your docker compose installation is working!
 
 Compose file explained:
 
-`version: '3'`: defines the API version that docker-compose should use
+`version: '3'`: defines the API version that docker compose should use
 `services:`:  defines the configuration of the container
 `hello-world:`: is now the name of the service
 `image: hello-world:latest`: defines the container and its version that we're using for `hello-world` service.

--- a/labs/docker-compose/02-port-forward.md
+++ b/labs/docker-compose/02-port-forward.md
@@ -4,7 +4,6 @@ Running arbitrary Linux commands inside a Docker container with docker compose i
 
 Create docker-compose.yml file with following content:
 ```yml
-version: '3'
 services:
     nginx:
         image: nginx:latest

--- a/labs/docker-compose/02-port-forward.md
+++ b/labs/docker-compose/02-port-forward.md
@@ -1,6 +1,6 @@
 # A basic webserver
 
-Running arbitrary Linux commands inside a Docker container with docker-compose is quite overhead, but let's do something more useful.
+Running arbitrary Linux commands inside a Docker container with docker compose is quite overhead, but let's do something more useful.
 
 Create docker-compose.yml file with following content:
 ```yml
@@ -10,7 +10,7 @@ services:
         image: nginx:latest
 ```
 
-Now run the command `docker-compose pull` and you should see:
+Now run the command `docker compose pull` and you should see:
 ```bash
 Pulling nginx ... done
 ```
@@ -38,7 +38,7 @@ If you see a webpage saying "Welcome to nginx!" then you're done!
 If you look at the console output from docker, you see nginx producing a line of text for each time a browser hits the webpage:
 
 ```bash
-$ docker-compose up
+$ docker compose up
 Creating docker-compose_nginx_1 ... done
 Attaching to docker-compose_nginx_1
 nginx_1  | 172.18.0.1 - - [07/Jan/2020:22:28:48 +0000] "GET / HTTP/1.1" 200 612 "-" "curl/7.58.0" "-"
@@ -51,19 +51,19 @@ Press **control + c** in your terminal window to stop your services.
 When running a webserver like nginx, it's pretty useful that you do not have to have an open session into the server at all times to run it.
 We need to make it run in the background, freeing up our terminal for other things.
 Docker enables this with the `-d` parameter for run.
-`docker-compose up -d`
+`docker compose up -d`
 
 ```bash
-$ docker-compose up -d
+$ docker compose up -d
 Starting docker-compose_nginx_1 ... done
 ```
 
 Docker prints out the service name and returns to the terminal.
 
-To see what services you've running from compose file you can use `docker-compose ps`
+To see what services you've running from compose file you can use `docker compose ps`
 
 _*Q: What is the status?*_
 
-To stop services you can run `docker-compose down`
+To stop services you can run `docker compose down`
 
 _*Q: What is the status after stopping?*_

--- a/labs/docker-compose/03-volumes.md
+++ b/labs/docker-compose/03-volumes.md
@@ -10,7 +10,6 @@ The server itself is of little use, if it cannot access our web content on the h
 We can define volumes with docker compose for the service like this:
 
 ```yml
-version: '3'
 services:
     nginx:
         image: nginx:latest

--- a/labs/docker-compose/03-volumes.md
+++ b/labs/docker-compose/03-volumes.md
@@ -7,7 +7,7 @@ In some cases you're going to need data outside of docker containers and to do t
 So let's look at the [Nginx](https://hub.docker.com/_/nginx/) service from port-forwarding excercise.
 The server itself is of little use, if it cannot access our web content on the host.
 
-We can define volumes with docker-compose for the service like this:
+We can define volumes with docker compose for the service like this:
 
 ```yml
 version: '3'

--- a/labs/docker-compose/04-build-image.md
+++ b/labs/docker-compose/04-build-image.md
@@ -17,7 +17,6 @@ Application can be started with command `python3 /path/to/app.py` and requiremen
 
 Your `docker-compose.yml` can look something like this:
 ```yml
-version: '3'
 services:
     bottle:
       build: ./bottle/

--- a/labs/docker-compose/04-build-image.md
+++ b/labs/docker-compose/04-build-image.md
@@ -26,7 +26,7 @@ services:
 
 Where `build:` is refering the folder what docker container we should build.
 
-To make docker-compose to build you can use command `docker-compose up --build` in order to execute the `build:` configuration.
+To make docker compose to build you can use command `docker compose up --build` in order to execute the `build:` configuration.
 
 Try to build your application container and open browser to correct port.
 

--- a/labs/extra-exercises/nginx/docker-compose.yml
+++ b/labs/extra-exercises/nginx/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   one:
     image: nginx:latest

--- a/labs/extra-exercises/nginx/network.md
+++ b/labs/extra-exercises/nginx/network.md
@@ -6,12 +6,12 @@ In this exercise, we all use this for creating a `nginx` server that serves cont
 
 ## Creating the containers
 
-There's a `docker-compose.yml` in this folder that contains the necessary configuration to spin up three nginx containers, configured to be a master nginx container. Then do a `docker-compose up -d`. When you open a browser window, go to http://localhost:9090/ You'll see the default page from a new `nginx` installation. The configuration file here makes two entry points for the two containers. In the configuration, the host names are used, instead of IP addresses, Docker assigns IP addresses to containers, but the values can vary between runs. If you inspect the docker containers, you'll see a section with `Networks`, where the alias is listed . When docker containers are created, a host name is assigned to them, which is by default the same as the container name. In the `nginx` configuration file, the host names are used without the ports defined in the above example; this is because docker has an internal network, and the `nginx` image by default exposes port 80.
+There's a `docker-compose.yml` in this folder that contains the necessary configuration to spin up three nginx containers, configured to be a master nginx container. Then do a `docker compose up -d`. When you open a browser window, go to http://localhost:9090/ You'll see the default page from a new `nginx` installation. The configuration file here makes two entry points for the two containers. In the configuration, the host names are used, instead of IP addresses, Docker assigns IP addresses to containers, but the values can vary between runs. If you inspect the docker containers, you'll see a section with `Networks`, where the alias is listed . When docker containers are created, a host name is assigned to them, which is by default the same as the container name. In the `nginx` configuration file, the host names are used without the ports defined in the above example; this is because docker has an internal network, and the `nginx` image by default exposes port 80.
 
 ## Running the containers
 
 Start the containers
 
-    $ docker-compose up -d
+    $ docker compose up -d
 
 The port numbers that are exposed were chosen a bit arbitrarily. You can remove the port configuration from container `one` and `two`, and see if the setup still works.

--- a/labs/multi-container/docker-compose.yaml
+++ b/labs/multi-container/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   #  wordpress_container:
 

--- a/labs/multi-container/docker-compose_final.yaml
+++ b/labs/multi-container/docker-compose_final.yaml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   wordpress_container:
     image: wordpress:5.7.2-apache

--- a/trainer/examples/basic-compose/README.md
+++ b/trainer/examples/basic-compose/README.md
@@ -21,4 +21,4 @@ Show compose content
 Run with:
 `docker compose up` and demo that it is running, then stop again with `docker compose down`.
 
-Then show again with `docker-compose up -d`
+Then show again with `docker compose up -d`

--- a/trainer/examples/basic-compose/docker-compose.yml
+++ b/trainer/examples/basic-compose/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   app:
     image: basic-compose:latest

--- a/trainer/examples/nextcloud/README.md
+++ b/trainer/examples/nextcloud/README.md
@@ -1,6 +1,6 @@
 # Nextcloud showcase
 
-An example of starting a two-container application using docker-compose;  Nextcloud with a MariaDB backend.
+An example of starting a two-container application using docker compose;  Nextcloud with a MariaDB backend.
 
 We show that the volumes persist killing the containers,
 and a version-upgrade of Nextcloud.
@@ -12,7 +12,7 @@ Tags: docker-compose, volumes, upgrading
 1. Start the application with:
 
     ```shell
-    docker-compose up
+    docker compose up
     ```
 
 1. Visit Nextcloud in a browser on: [localhost](http://localhost),
@@ -35,11 +35,11 @@ and create an admin account.
 to upload it to your Nextcloud.
 
 1. Stop the services afterwards.
-    > If you ran `docker-compose` without `-d`,
+    > If you ran `docker compose` without `-d`,
     > then `ctrl+c` will stop the services.
 
     ```shell
-    docker-compose down
+    docker compose down
     ```
 
 1. Reload the window in the browser; Nextcloud is down.
@@ -54,7 +54,7 @@ to upload it to your Nextcloud.
 1. You can even remove the containers:
 
     ```shell
-    docker-compose rm
+    docker compose rm
     ```
 
 1. Show that they're gone with `docker ps -a`.
@@ -64,7 +64,7 @@ to upload it to your Nextcloud.
 1. Start the application again with,
 
     ```shell
-    docker-compose up
+    docker compose up
     ```
 
 1. Reload your browser window,
@@ -77,14 +77,14 @@ you might even still be logged in.
 
 ## Part 2: Upgrading Nextcloud
 
-1. Stop the services again, using `docker-compose down` or `ctrl+c`.
+1. Stop the services again, using `docker compose down` or `ctrl+c`.
 1. Change the version of the Nextcloud image from `nextcloud:X`
     to `nextcloud:X+1` (swap the commented image-version lines,
     in the `docker-compose.yml`.)
 
 ## Start the Application
 
-1. Run `docker-compose up` to start the application.
+1. Run `docker compose up` to start the application.
 
 You can find the version under the `gear icon -> help`,
 [link](http://localhost/settings/help).
@@ -94,9 +94,9 @@ You can find the version under the `gear icon -> help`,
 > Downgrading is not supported in Nextcloud.
 
 1. Try stopping the containers again
-with `docker-compose down` or `ctrl+c`.
+with `docker compose down` or `ctrl+c`.
 1. Changing the version back to `nextcloud:12`.
-1. Starting the application again with `docker-compose up`.
+1. Starting the application again with `docker compose up`.
 
 Nextcloud will fail to start with the message:
 
@@ -114,7 +114,7 @@ app_1  | Can't start Nextcloud because the version of the data (12.0.13.2) is hi
 
 In the original example,
 the upgrade would fail without adding the `depends_on: db`
-to the docker-compose file.
+to the docker compose file.
 Nicolaj has been unable to reproduce this error on `Docker for Windows 19.03`, and thus the "example of using `depends_on`" is left out of the tutorial.
-`depends_on` is however kept in the docker-compose file,
+`depends_on` is however kept in the docker compose file,
 so as to not cause any unintentional errors.

--- a/trainer/examples/nextcloud/docker-compose.yml
+++ b/trainer/examples/nextcloud/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 volumes:
   nextcloud:
   db:


### PR DESCRIPTION
docker-compose no longer installed in the training environments, only the `docker compose` plugin.
Whilst we can define an `alias docker-compose="docker compose"`, it may be confusing.

Docker compose v2 has also deprecated the version field.